### PR TITLE
wgpu-native package and example

### DIFF
--- a/examples/c-wgpu/.gitignore
+++ b/examples/c-wgpu/.gitignore
@@ -1,0 +1,4 @@
+.spack-env
+spack.lock
+build
+bin

--- a/examples/c-wgpu/Makefile
+++ b/examples/c-wgpu/Makefile
@@ -1,0 +1,32 @@
+init: .spack-env
+.PHONY:
+
+configure:
+	rm -rf build
+	genie gmake
+.PHONY: configure
+
+build:
+	(cd build && make)
+.PHONY: build
+
+run:
+	(cd src && ../bin/triangle_x64_d)
+.PHONY: run
+
+env: .spack-env
+.PHONY: env
+
+.spack-env: spack.yaml
+	spack env create -d .
+	spack -e . install --reuse
+	echo "activate with: spacktivate ."
+
+clean:
+	rm -rf bin build
+.PHONY: clean
+
+clean-all: clean
+	rm -rf .spack-env
+	rm -f spack.lock
+.PHONY: clean

--- a/examples/c-wgpu/README.md
+++ b/examples/c-wgpu/README.md
@@ -1,0 +1,20 @@
+
+
+# Using the Genie build system
+
+Simple example of using snailpacks and Spack for writing code using
+some libraries installed via Spack.
+
+```sh
+# install dependencies via spack into local view
+make init
+
+# generate project files
+make configure
+
+# run the build
+make build
+
+# run the executable
+make run
+```

--- a/examples/c-wgpu/genie.lua
+++ b/examples/c-wgpu/genie.lua
@@ -1,0 +1,49 @@
+solution "WgpuNativeTriangleExample"
+    configurations { "debug", "release" }
+    location "build"
+    platforms {"x64"}
+    startproject "TriangleExample"
+    targetdir "bin"
+    debugdir "bin"
+
+    configuration {"x64", "debug"}
+        targetsuffix "_x64_debug"
+
+    configuration {"x64", "release"}
+        targetsuffix "_x64"
+
+    configuration "debug"
+        defines { "DEBUG" }
+        flags { "Symbols" }
+        objdir "build/debug"
+
+    configuration "release"
+        defines { "NDEBUG"}
+        flags { "Optimize" }
+        objdir "build/release"
+
+    configuration {"gmake"}
+        buildoptions {
+           "-Wall",
+           "-Wextra",
+           "-pedantic"
+        }
+
+    configuration {"linux"}
+        defines {"WGPU_TARGET=WGPU_TARGET_LINUX_X11"}
+
+
+project "TriangleExample"
+    kind "ConsoleApp"
+    language "C"
+    targetdir "bin"
+    targetname "triangle"
+
+    files {"src/**.c"}
+
+
+    includedirs {"include", ".spack-env/view/include"}
+    libdirs { ".spack-env/view/lib" }
+
+    links { "wgpu_native", "glfw" }
+

--- a/examples/c-wgpu/include/framework.h
+++ b/examples/c-wgpu/include/framework.h
@@ -1,0 +1,15 @@
+#include "wgpu.h"
+
+WGPUShaderModuleDescriptor load_wgsl(const char *name);
+
+void request_adapter_callback(WGPURequestAdapterStatus status,
+                              WGPUAdapter received, const char *message,
+                              void *userdata);
+
+void request_device_callback(WGPURequestDeviceStatus status,
+                             WGPUDevice received, const char *message,
+                             void *userdata);
+
+void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata);
+
+void initializeLog();

--- a/examples/c-wgpu/include/helper.h
+++ b/examples/c-wgpu/include/helper.h
@@ -1,0 +1,11 @@
+typedef struct BufferDimensions {
+  size_t width;
+  size_t height;
+  size_t unpadded_bytes_per_row;
+  size_t padded_bytes_per_row;
+} BufferDimensions;
+
+BufferDimensions buffer_dimensions_new(size_t width, size_t height);
+
+void save_png(const char *path, const unsigned char *data,
+              const BufferDimensions *buffer_dimensions);

--- a/examples/c-wgpu/include/unused.h
+++ b/examples/c-wgpu/include/unused.h
@@ -1,0 +1,1 @@
+#define UNUSED(x) (void)x

--- a/examples/c-wgpu/spack.yaml
+++ b/examples/c-wgpu/spack.yaml
@@ -1,0 +1,10 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  specs:
+  - wgpu-native@0.12.0.1
+  - glfw@3.3.6
+  view: true
+  concretization: together

--- a/examples/c-wgpu/src/framework.c
+++ b/examples/c-wgpu/src/framework.c
@@ -1,0 +1,72 @@
+#include "webgpu-headers/webgpu.h"
+#include "wgpu.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+WGPUShaderModuleDescriptor load_wgsl(const char *name) {
+  FILE *file = fopen(name, "rb");
+  if (!file) {
+    printf("Unable to open %s\n", name);
+    exit(1);
+  }
+  fseek(file, 0, SEEK_END);
+  long length = ftell(file);
+  unsigned char *bytes = malloc(length + 1);
+  fseek(file, 0, SEEK_SET);
+  fread(bytes, 1, length, file);
+  fclose(file);
+  bytes[length] = 0;
+
+  WGPUShaderModuleWGSLDescriptor *wgslDescriptor =
+      malloc(sizeof(WGPUShaderModuleWGSLDescriptor));
+  wgslDescriptor->chain.next = NULL;
+  wgslDescriptor->chain.sType = WGPUSType_ShaderModuleWGSLDescriptor;
+  wgslDescriptor->code = (const char *)bytes;
+  return (WGPUShaderModuleDescriptor){
+      .nextInChain = (const WGPUChainedStruct *)wgslDescriptor,
+      .label = name,
+  };
+}
+
+void request_adapter_callback(WGPURequestAdapterStatus status,
+                              WGPUAdapter received, const char *message,
+                              void *userdata) {
+  *(WGPUAdapter *)userdata = received;
+}
+
+void request_device_callback(WGPURequestDeviceStatus status,
+                             WGPUDevice received, const char *message,
+                             void *userdata) {
+  *(WGPUDevice *)userdata = received;
+}
+
+void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {}
+
+void logCallback(WGPULogLevel level, const char *msg) {
+  char *level_str;
+  switch (level) {
+  case WGPULogLevel_Error:
+    level_str = "Error";
+    break;
+  case WGPULogLevel_Warn:
+    level_str = "Warn";
+    break;
+  case WGPULogLevel_Info:
+    level_str = "Info";
+    break;
+  case WGPULogLevel_Debug:
+    level_str = "Debug";
+    break;
+  case WGPULogLevel_Trace:
+    level_str = "Trace";
+    break;
+  default:
+    level_str = "Unknown Level";
+  }
+  printf("[%s] %s\n", level_str, msg);
+}
+
+void initializeLog() {
+  wgpuSetLogCallback(logCallback);
+  wgpuSetLogLevel(WGPULogLevel_Warn);
+}

--- a/examples/c-wgpu/src/main.c
+++ b/examples/c-wgpu/src/main.c
@@ -1,0 +1,342 @@
+#include "webgpu-headers/webgpu.h"
+#include "wgpu.h"
+
+#include "framework.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#define WGPU_TARGET_MACOS 1
+#define WGPU_TARGET_LINUX_X11 2
+#define WGPU_TARGET_WINDOWS 3
+#define WGPU_TARGET_LINUX_WAYLAND 4
+
+#if WGPU_TARGET == WGPU_TARGET_MACOS
+#include <Foundation/Foundation.h>
+#include <QuartzCore/CAMetalLayer.h>
+#endif
+
+#include <GLFW/glfw3.h>
+#if WGPU_TARGET == WGPU_TARGET_MACOS
+#define GLFW_EXPOSE_NATIVE_COCOA
+#elif WGPU_TARGET == WGPU_TARGET_LINUX_X11
+#define GLFW_EXPOSE_NATIVE_X11
+#elif WGPU_TARGET == WGPU_TARGET_LINUX_WAYLAND
+#define GLFW_EXPOSE_NATIVE_WAYLAND
+#elif WGPU_TARGET == WGPU_TARGET_WINDOWS
+#define GLFW_EXPOSE_NATIVE_WIN32
+#endif
+#include <GLFW/glfw3native.h>
+
+static void handle_device_lost(WGPUDeviceLostReason reason, char const * message, void * userdata)
+{
+  printf("DEVICE LOST (%d): %s\n", reason, message);
+}
+
+static void handle_uncaptured_error(WGPUErrorType type, char const * message, void * userdata)
+{
+  printf("UNCAPTURED ERROR (%d): %s\n", type, message);
+}
+
+int main() {
+  initializeLog();
+
+  if (!glfwInit()) {
+    printf("Cannot initialize glfw");
+    return 1;
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  GLFWwindow *window = glfwCreateWindow(640, 480, "wgpu with glfw", NULL, NULL);
+
+  if (!window) {
+    printf("Cannot create window");
+    return 1;
+  }
+
+  WGPUSurface surface;
+
+#if WGPU_TARGET == WGPU_TARGET_MACOS
+  {
+    id metal_layer = NULL;
+    NSWindow *ns_window = glfwGetCocoaWindow(window);
+    [ns_window.contentView setWantsLayer:YES];
+    metal_layer = [CAMetalLayer layer];
+    [ns_window.contentView setLayer:metal_layer];
+    surface = wgpuInstanceCreateSurface(
+        NULL,
+        &(WGPUSurfaceDescriptor){
+            .label = NULL,
+            .nextInChain =
+                (const WGPUChainedStruct *)&(
+                    WGPUSurfaceDescriptorFromMetalLayer){
+                    .chain =
+                        (WGPUChainedStruct){
+                            .next = NULL,
+                            .sType = WGPUSType_SurfaceDescriptorFromMetalLayer,
+                        },
+                    .layer = metal_layer,
+                },
+        });
+  }
+#elif WGPU_TARGET == WGPU_TARGET_LINUX_X11
+  {
+    Display *x11_display = glfwGetX11Display();
+    Window x11_window = glfwGetX11Window(window);
+    surface = wgpuInstanceCreateSurface(
+        NULL,
+        &(WGPUSurfaceDescriptor){
+            .label = NULL,
+            .nextInChain =
+                (const WGPUChainedStruct *)&(WGPUSurfaceDescriptorFromXlibWindow){
+                    .chain =
+                        (WGPUChainedStruct){
+                            .next = NULL,
+                            .sType = WGPUSType_SurfaceDescriptorFromXlibWindow,
+                        },
+                    .display = x11_display,
+                    .window = x11_window,
+                },
+        });
+  }
+#elif WGPU_TARGET == WGPU_TARGET_LINUX_WAYLAND
+  {
+    struct wl_display *wayland_display = glfwGetWaylandDisplay();
+    struct wl_surface *wayland_surface = glfwGetWaylandWindow(window);
+    surface = wgpuInstanceCreateSurface(
+        NULL,
+        &(WGPUSurfaceDescriptor){
+            .label = NULL,
+            .nextInChain =
+                (const WGPUChainedStruct *)&(
+                    WGPUSurfaceDescriptorFromWaylandSurface){
+                    .chain =
+                        (WGPUChainedStruct){
+                            .next = NULL,
+                            .sType =
+                                WGPUSType_SurfaceDescriptorFromWaylandSurface,
+                        },
+                    .display = wayland_display,
+                    .surface = wayland_surface,
+                },
+        });
+  }
+#elif WGPU_TARGET == WGPU_TARGET_WINDOWS
+  {
+    HWND hwnd = glfwGetWin32Window(window);
+    HINSTANCE hinstance = GetModuleHandle(NULL);
+    surface = wgpuInstanceCreateSurface(
+        NULL,
+        &(WGPUSurfaceDescriptor){
+            .label = NULL,
+            .nextInChain =
+                (const WGPUChainedStruct *)&(
+                    WGPUSurfaceDescriptorFromWindowsHWND){
+                    .chain =
+                        (WGPUChainedStruct){
+                            .next = NULL,
+                            .sType = WGPUSType_SurfaceDescriptorFromWindowsHWND,
+                        },
+                    .hinstance = hinstance,
+                    .hwnd = hwnd,
+                },
+        });
+  }
+#else
+#error "Unsupported WGPU_TARGET"
+#endif
+
+  WGPUAdapter adapter;
+  wgpuInstanceRequestAdapter(NULL,
+                             &(WGPURequestAdapterOptions){
+                                 .nextInChain = NULL,
+                                 .compatibleSurface = surface,
+                             },
+                             request_adapter_callback, (void *)&adapter);
+
+  WGPUDevice device;
+  wgpuAdapterRequestDevice(
+      adapter,
+      &(WGPUDeviceDescriptor){
+          .nextInChain =
+              (const WGPUChainedStruct *)&(WGPUDeviceExtras){
+                  .chain =
+                      (WGPUChainedStruct){
+                          .next = NULL,
+                          .sType = WGPUSType_DeviceExtras,
+                      },
+                  .label = "Device",
+                  .tracePath = NULL,
+              },
+          .requiredLimits =
+              &(WGPURequiredLimits){
+                  .nextInChain = NULL,
+                  .limits =
+                      (WGPULimits){
+                          .maxBindGroups = 1,
+                      },
+              },
+      },
+      request_device_callback, (void *)&device);
+
+  wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
+  wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);
+
+  WGPUShaderModuleDescriptor shaderSource = load_wgsl("shader.wgsl");
+  WGPUShaderModule shader = wgpuDeviceCreateShaderModule(device, &shaderSource);
+
+  WGPUPipelineLayout pipelineLayout = wgpuDeviceCreatePipelineLayout(
+      device, &(WGPUPipelineLayoutDescriptor){.bindGroupLayouts = NULL,
+                                              .bindGroupLayoutCount = 0});
+
+  WGPUTextureFormat swapChainFormat =
+      wgpuSurfaceGetPreferredFormat(surface, adapter);
+
+  WGPURenderPipeline pipeline = wgpuDeviceCreateRenderPipeline(
+      device,
+      &(WGPURenderPipelineDescriptor){
+          .label = "Render pipeline",
+          .layout = pipelineLayout,
+          .vertex =
+              (WGPUVertexState){
+                  .module = shader,
+                  .entryPoint = "vs_main",
+                  .bufferCount = 0,
+                  .buffers = NULL,
+              },
+          .primitive =
+              (WGPUPrimitiveState){
+                  .topology = WGPUPrimitiveTopology_TriangleList,
+                  .stripIndexFormat = WGPUIndexFormat_Undefined,
+                  .frontFace = WGPUFrontFace_CCW,
+                  .cullMode = WGPUCullMode_None},
+          .multisample =
+              (WGPUMultisampleState){
+                  .count = 1,
+                  .mask = ~0,
+                  .alphaToCoverageEnabled = false,
+              },
+          .fragment =
+              &(WGPUFragmentState){
+                  .module = shader,
+                  .entryPoint = "fs_main",
+                  .targetCount = 1,
+                  .targets =
+                      &(WGPUColorTargetState){
+                          .format = swapChainFormat,
+                          .blend =
+                              &(WGPUBlendState){
+                                  .color =
+                                      (WGPUBlendComponent){
+                                          .srcFactor = WGPUBlendFactor_One,
+                                          .dstFactor = WGPUBlendFactor_Zero,
+                                          .operation = WGPUBlendOperation_Add,
+                                      },
+                                  .alpha =
+                                      (WGPUBlendComponent){
+                                          .srcFactor = WGPUBlendFactor_One,
+                                          .dstFactor = WGPUBlendFactor_Zero,
+                                          .operation = WGPUBlendOperation_Add,
+                                      }},
+                          .writeMask = WGPUColorWriteMask_All},
+              },
+          .depthStencil = NULL,
+      });
+
+  int prevWidth = 0;
+  int prevHeight = 0;
+  glfwGetWindowSize(window, &prevWidth, &prevHeight);
+
+  WGPUSwapChain swapChain =
+      wgpuDeviceCreateSwapChain(device, surface,
+                                &(WGPUSwapChainDescriptor){
+                                    .usage = WGPUTextureUsage_RenderAttachment,
+                                    .format = swapChainFormat,
+                                    .width = prevWidth,
+                                    .height = prevHeight,
+                                    .presentMode = WGPUPresentMode_Fifo,
+                                });
+
+  while (!glfwWindowShouldClose(window)) {
+
+    WGPUTextureView nextTexture = NULL;
+
+    for (int attempt = 0; attempt < 2; attempt++) {
+
+      int width = 0;
+      int height = 0;
+      glfwGetWindowSize(window, &width, &height);
+
+      if (width != prevWidth || height != prevHeight) {
+        prevWidth = width;
+        prevHeight = height;
+
+        swapChain = wgpuDeviceCreateSwapChain(
+            device, surface,
+            &(WGPUSwapChainDescriptor){
+                .usage = WGPUTextureUsage_RenderAttachment,
+                .format = swapChainFormat,
+                .width = prevWidth,
+                .height = prevHeight,
+                .presentMode = WGPUPresentMode_Fifo,
+            });
+      }
+
+      nextTexture = wgpuSwapChainGetCurrentTextureView(swapChain);
+
+      if (attempt == 0 && !nextTexture) {
+        printf("wgpuSwapChainGetCurrentTextureView() failed; trying to create a new swap chain...\n");
+        prevWidth = 0;
+        prevHeight = 0;
+        continue;
+      }
+
+      break;
+    }
+
+    if (!nextTexture) {
+      printf("Cannot acquire next swap chain texture\n");
+      return 1;
+    }
+
+    WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(
+        device, &(WGPUCommandEncoderDescriptor){.label = "Command Encoder"});
+
+    WGPURenderPassEncoder renderPass = wgpuCommandEncoderBeginRenderPass(
+        encoder, &(WGPURenderPassDescriptor){
+                     .colorAttachments =
+                         &(WGPURenderPassColorAttachment){
+                             .view = nextTexture,
+                             .resolveTarget = 0,
+                             .loadOp = WGPULoadOp_Clear,
+                             .storeOp = WGPUStoreOp_Store,
+                             .clearValue =
+                                 (WGPUColor){
+                                     .r = 0.0,
+                                     .g = 1.0,
+                                     .b = 0.0,
+                                     .a = 1.0,
+                                 },
+                         },
+                     .colorAttachmentCount = 1,
+                     .depthStencilAttachment = NULL,
+                 });
+
+    wgpuRenderPassEncoderSetPipeline(renderPass, pipeline);
+    wgpuRenderPassEncoderDraw(renderPass, 3, 1, 0, 0);
+    wgpuRenderPassEncoderEnd(renderPass);
+
+    WGPUQueue queue = wgpuDeviceGetQueue(device);
+    WGPUCommandBuffer cmdBuffer = wgpuCommandEncoderFinish(
+        encoder, &(WGPUCommandBufferDescriptor){.label = NULL});
+    wgpuQueueSubmit(queue, 1, &cmdBuffer);
+    wgpuSwapChainPresent(swapChain);
+
+    glfwPollEvents();
+  }
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+
+  return 0;
+}
+

--- a/examples/c-wgpu/src/shader.wgsl
+++ b/examples/c-wgpu/src/shader.wgsl
@@ -1,0 +1,11 @@
+@stage(vertex)
+fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> @builtin(position) vec4<f32> {
+    let x = f32(i32(in_vertex_index) - 1);
+    let y = f32(i32(in_vertex_index & 1u) * 2 - 1);
+    return vec4<f32>(x, y, 0.0, 1.0);
+}
+
+@stage(fragment)
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}

--- a/packages/webgpu-headers/package.py
+++ b/packages/webgpu-headers/package.py
@@ -1,0 +1,43 @@
+from spack import *
+
+from pathlib import Path
+import shutil as sh
+
+class WebgpuHeaders(Package):
+    """Header fles for the WebGPU API."""
+
+    maintainers = ['salotz',]
+
+    homepage = "https://github.com/webgpu-native/webgpu-headers"
+
+    git = "https://github.com/webgpu-native/webgpu-headers.git"
+
+    # There are no versions of this and the packages that use them
+    # just use the hash as the version so we just use the date it was
+    # published
+
+    version(
+        '2022-03-22',
+        commit='b46ca3c39249c537b2b421a37cf06b0d20bbf2c1',
+    )
+
+    def install(self, spec, prefix):
+
+        # then make a copy of the repo into share because
+        # unfortunately many of the dependents require this
+        prefix_path = Path(prefix)
+
+        (prefix_path / 'include').mkdir()
+        (prefix_path / 'share').mkdir()
+
+        # copy this whole repo into share in case you have a
+        # dependency which needs it done this way
+        sh.copyfile(
+            "./webgpu.h",
+            prefix_path / "include" / "webgpu.h"
+        )
+
+        sh.copytree(
+            ".",
+            prefix_path / "share" / "repo"
+        )

--- a/packages/webgpu-headers/package.py
+++ b/packages/webgpu-headers/package.py
@@ -27,14 +27,14 @@ class WebgpuHeaders(Package):
         # unfortunately many of the dependents require this
         prefix_path = Path(prefix)
 
-        (prefix_path / 'include').mkdir()
+        (prefix_path / 'include' / 'webgpu-headers').mkdir(parents=True)
         (prefix_path / 'share').mkdir()
 
         # copy this whole repo into share in case you have a
         # dependency which needs it done this way
         sh.copyfile(
             "./webgpu.h",
-            prefix_path / "include" / "webgpu.h"
+            prefix_path / "include" / "webgpu-headers" / "webgpu.h"
         )
 
         sh.copytree(

--- a/packages/wgpu-native/package.py
+++ b/packages/wgpu-native/package.py
@@ -1,0 +1,99 @@
+from spack.package import *
+
+from pathlib import Path
+import shutil as sh
+
+
+class WgpuNative(Package):
+    """This is a native WebGPU implementation in Rust, based on
+    wgpu-core.
+
+    The bindings are based on the WebGPU-native header found at
+    ffi/webgpu-headers/webgpu.h and wgpu-native specific items in
+    ffi/wgpu.h
+
+    """
+
+    homepage = "https://github.com/gfx-rs/wgpu-native"
+    url = "https://github.com/gfx-rs/wgpu-native/archive/refs/tags/v0.12.0.1.tar.gz"
+
+    version('0.12.0.1',
+            sha256='b555b1d27216b53e205310849cbf32ffdf796c465443d17efce7051fa9b052c0',)
+    # version('0.11.0.1',
+    #         sha256='9abb7b4381eb61ae49d96d6f8078cbdf307e3155a7e56dc7d61a8d344f0777e0')
+    # version('0.10.4.1',
+    #         sha256='0c700bdf97f30b561b6eaf303b7c13ca1ecb82b63a1fc26fd169d5d53d0a7508')
+
+
+    depends_on("rust")
+
+    depends_on('webgpu-headers@2022-03-22',
+               when='@0.12.0.1',
+               )
+
+    # TODO: the rest of the older versions, don't really care to do
+    # them all now
+
+    variant('build_type',
+            default='debug',
+            description='Type of build to generate, passed to "config={value}"',
+            values=('release', 'debug',),
+            multi=False,
+            )
+
+    def install(self, spec, prefix):
+
+        # install the header files for webgpu
+        prefix_path = Path(prefix)
+
+        (prefix_path / 'lib').mkdir()
+        (prefix_path / 'include').mkdir()
+
+
+        webgpu_headers_prefix = Path(spec['webgpu-headers'].prefix)
+
+        src_path = webgpu_headers_prefix / "include" / "webgpu.h"
+
+        dest_path = Path('.') / "ffi" / "webgpu-headers" / "webgpu.h"
+
+        dest_path.symlink_to(src_path)
+
+        # build the package
+        cargo = which("cargo")
+
+        build_type = spec.variants['build_type'].value
+
+        if build_type == 'release':
+            target_name = build_type
+            cargo('build' '-r')
+
+        elif build_type == 'debug':
+            target_name = build_type
+            cargo('build')
+        else:
+            raise ValueError(f"Unknown build_type {build_type}")
+
+        # then copy the binaries
+        build_path = Path('.') / 'target' / target_name
+
+        for path in build_path.glob('*.a'):
+            sh.copyfile(path, prefix_path / 'lib' / path.name)
+
+        for path in build_path.glob('*.so'):
+            sh.copyfile(path, prefix_path / 'lib' / path.name)
+
+        # NOTE: not sure we want the rust libs so I'll leave out
+
+        # for path in build_path.glob('lib*.rlib'):
+        #     sh.copyfile(path, prefix_path / 'lib' / path.name)
+
+        ## Install the headers
+
+        # put the wgpu.h into the installed include
+        sh.copyfile(Path('.') / 'ffi' / 'wgpu.h',
+                    prefix_path / 'include' / 'wgpu.h'
+                    )
+
+        sh.copyfile(Path('.') / 'ffi' / 'webgpu-headers' / 'webgpu.h',
+                    prefix_path / 'include' / 'webgpu.h'
+                    )

--- a/packages/wgpu-native/package.py
+++ b/packages/wgpu-native/package.py
@@ -94,6 +94,7 @@ class WgpuNative(Package):
                     prefix_path / 'include' / 'wgpu.h'
                     )
 
+        (prefix_path / 'include' / 'webgpu-headers').mkdir()
         sh.copyfile(Path('.') / 'ffi' / 'webgpu-headers' / 'webgpu.h',
-                    prefix_path / 'include' / 'webgpu.h'
+                    prefix_path / 'include' / 'webgpu-headers' / 'webgpu.h'
                     )


### PR DESCRIPTION
- adds packages for: wgpu-native and wgpu-headers
  - No effort was done to split up the Cargo dependencies so there are a bunch of out-of-tree dependencies that it installs
- Adds an example of using genie to do an example project with wgpu-native